### PR TITLE
Fix handlers trigger

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,14 +1,5 @@
 ---
-# handlers file for netplan-networking
 
-- name: restart networkd
+- name: apply network interface
   become: true
-  service:
-    name: systemd-networkd
-    state: restarted
-
-- name: restart resolved
-  become: true
-  service:
-    name: systemd-resolved
-    state: restarted
+  shell: netplan apply

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,9 +11,4 @@
     mode: 0644
   with_items: "{{ interfaces }}"
   notify:
-    - restart networkd
-    - restart resolved
-
-- name: Apply network interface configuration
-  become: true
-  shell: netplan apply
+    - apply network interface


### PR DESCRIPTION
Thank you for this great module. 
Moving `netplan apply` to handlers will trigger it only in case of any changes of the configurations. In current state it's triggered on each ansible execution.
Having `systemd-resolved` and `networkd` doesn't work in my test env and i'm not sure why do you trigger it.
