### PR TITLE
Changed netplan file permissions from 0644 to 0600

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
     dest: "/etc/netplan/{{ item.interface }}.yaml"
     owner: root
     group: root
-    mode: 0644
+    mode: 0600
   with_items: "{{ interfaces }}"
   notify:
     - apply network interface


### PR DESCRIPTION
Changed netplan file permissions from 0644 to 0600 to resolve warnings from netplan. See [#3](https://github.com/d3atiq/netplan-networking/issues/3).